### PR TITLE
Initial port for ROCm and skipping tests in tests/distributions, tests/infer and tests/ops/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-all: lint FORCE
 	  | xargs pytest -vx --nbval-lax
 
 test-cuda: lint FORCE
-	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx --stage unit
+	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx --stage unit --ignore=tests/contrib/gp/test_conditional.py
 	CUDA_TEST=1 pytest -vx tests/test_examples.py::test_cuda
 
 test-cuda-lax: lint FORCE

--- a/tests/common.py
+++ b/tests/common.py
@@ -63,6 +63,11 @@ skipif_rocm = pytest.mark.skipif(rocm_env,
                                  reason="test not supported on ROCm")
 
 
+def skip_param_rocm(*args):
+    return skipif_param(*args, condition=("CUDA_TEST" in os.environ) and rocm_env,
+                        reason="parameter not supported on rocm")
+
+
 def get_cpu_type(t):
     assert t.__module__ == 'torch.cuda'
     return getattr(torch, t.__class__.__name__)

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,6 +58,9 @@ def TemporaryDirectory():
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(),
                                    reason="cuda is not available")
+rocm_env = torch.cuda.is_available() and (torch.version.hip is not None)
+skipif_rocm = pytest.mark.skipif(rocm_env,
+                                 reason="test not supported on ROCm")
 
 
 def get_cpu_type(t):

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 from torch.autograd import grad
 
-from tests.common import assert_equal, requires_cuda, tensors_default_to, xfail_if_not_implemented
+from tests.common import assert_equal, requires_cuda, tensors_default_to, xfail_if_not_implemented, skipif_rocm
 
 
 @requires_cuda
+@skipif_rocm
 def test_sample(dist):
     for idx in range(len(dist.dist_params)):
 
@@ -32,6 +33,7 @@ def test_sample(dist):
 
 
 @requires_cuda
+@skipif_rocm
 def test_rsample(dist):
     if not dist.pyro_dist.has_rsample:
         return
@@ -71,6 +73,7 @@ def test_rsample(dist):
 
 
 @requires_cuda
+@skipif_rocm
 def test_log_prob(dist):
     for idx in range(len(dist.dist_params)):
 

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -9,7 +9,7 @@ import pyro
 import pyro.distributions as dist
 from pyro.distributions import TorchDistribution
 from pyro.distributions.util import broadcast_shape
-from tests.common import assert_equal, xfail_if_not_implemented
+from tests.common import assert_equal, xfail_if_not_implemented, skipif_rocm
 
 
 def _log_prob_shape(dist, x_size=torch.Size()):
@@ -22,6 +22,7 @@ def _log_prob_shape(dist, x_size=torch.Size()):
 # Distribution tests - all distributions
 
 
+@skipif_rocm
 def test_batch_log_prob(dist):
     if dist.scipy_arg_fn is None:
         pytest.skip('{}.log_prob_sum has no scipy equivalent'.format(dist.pyro_dist.__name__))
@@ -34,6 +35,7 @@ def test_batch_log_prob(dist):
         assert_equal(log_prob_sum_pyro, log_prob_sum_np)
 
 
+@skipif_rocm
 def test_batch_log_prob_shape(dist):
     for idx in range(dist.get_num_test_data()):
         dist_params = dist.get_dist_params(idx)
@@ -46,6 +48,7 @@ def test_batch_log_prob_shape(dist):
             assert log_p_obj.size() == expected_shape
 
 
+@skipif_rocm
 def test_batch_entropy_shape(dist):
     for idx in range(dist.get_num_test_data()):
         dist_params = dist.get_dist_params(idx)
@@ -57,6 +60,7 @@ def test_batch_entropy_shape(dist):
             assert entropy_obj.size() == expected_shape
 
 
+@skipif_rocm
 def test_score_errors_event_dim_mismatch(dist):
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
@@ -71,6 +75,7 @@ def test_score_errors_event_dim_mismatch(dist):
                 d.log_prob(test_data_wrong_dims)
 
 
+@skipif_rocm
 def test_score_errors_non_broadcastable_data_shape(dist):
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
@@ -144,6 +149,7 @@ def check_sample_shapes(small, large):
 
 @pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
 @pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
+@skipif_rocm
 def test_expand_by(dist, sample_shape, shape_type):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
@@ -157,6 +163,7 @@ def test_expand_by(dist, sample_shape, shape_type):
 @pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
 @pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
 @pytest.mark.parametrize('default', [False, True])
+@skipif_rocm
 def test_expand_new_dim(dist, sample_shape, shape_type, default):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
@@ -173,6 +180,7 @@ def test_expand_new_dim(dist, sample_shape, shape_type, default):
 
 @pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
 @pytest.mark.parametrize('default', [False, True])
+@skipif_rocm
 def test_expand_existing_dim(dist, shape_type, default):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
@@ -198,6 +206,7 @@ def test_expand_existing_dim(dist, shape_type, default):
     [(2, 1, 1), (2, 1, 3), (2, 5, 3)],
 ])
 @pytest.mark.parametrize('default', [False, True])
+@skipif_rocm
 def test_subsequent_expands_ok(dist, sample_shapes, default):
     for idx in range(dist.get_num_test_data()):
         d = dist.pyro_dist(**dist.get_dist_params(idx))
@@ -221,6 +230,7 @@ def test_subsequent_expands_ok(dist, sample_shapes, default):
     [(1, 2, 1), (2, 1)],
 ])
 @pytest.mark.parametrize("default", [False, True])
+@skipif_rocm
 def test_expand_error(dist, initial_shape, proposed_shape, default):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.distributions.empirical import Empirical
-from tests.common import assert_equal, assert_close
+from tests.common import assert_equal, assert_close, rocm_env
 
 
 @pytest.mark.parametrize("size", [[], [1], [2, 3]])
@@ -101,6 +101,7 @@ def test_log_prob(batch_shape, event_shape, dtype):
 
 @pytest.mark.parametrize("event_shape", [[], [1], [2, 3]])
 @pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+@pytest.mark.skipif(rocm_env, reason="error more than tolerance")
 def test_weighted_sample_coherence(event_shape, dtype):
     data = [(1.0, 0.5), (0.0, 1.5), (1.0, 0.5), (0.0, 1.5)]
     samples, weights = [], []

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -19,7 +19,7 @@ from pyro.ops.gamma_gaussian import (gamma_and_mvn_to_gamma_gaussian, gamma_gaus
                                      matrix_and_mvn_to_gamma_gaussian)
 from pyro.ops.gaussian import gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
 from pyro.ops.indexing import Vindex
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm
 from tests.ops.gamma_gaussian import assert_close_gamma_gaussian, random_gamma, random_gamma_gaussian
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
 
@@ -63,6 +63,7 @@ def test_sequential_logmatmulexp(batch_shape, state_dim, num_steps):
 @pytest.mark.parametrize('num_steps', list(range(1, 20)))
 @pytest.mark.parametrize('state_dim', [1, 2, 3])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 4)], ids=str)
+@skipif_rocm
 def test_sequential_gaussian_tensordot(batch_shape, state_dim, num_steps):
     g = random_gaussian(batch_shape + (num_steps,), state_dim + state_dim)
     actual = _sequential_gaussian_tensordot(g)
@@ -80,6 +81,7 @@ def test_sequential_gaussian_tensordot(batch_shape, state_dim, num_steps):
 @pytest.mark.parametrize('state_dim', [1, 2, 3])
 @pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize('sample_shape', [(), (4,), (3, 2)], ids=str)
+@skipif_rocm
 def test_sequential_gaussian_filter_sample(sample_shape, batch_shape, state_dim, num_steps):
     init = random_gaussian(batch_shape, state_dim)
     trans = random_gaussian(batch_shape + (num_steps,), state_dim + state_dim)
@@ -90,6 +92,7 @@ def test_sequential_gaussian_filter_sample(sample_shape, batch_shape, state_dim,
 @pytest.mark.parametrize('num_steps', list(range(1, 20)))
 @pytest.mark.parametrize('state_dim', [1, 2, 3])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 4)], ids=str)
+@skipif_rocm
 def test_sequential_gamma_gaussian_tensordot(batch_shape, state_dim, num_steps):
     g = random_gamma_gaussian(batch_shape + (num_steps,), state_dim + state_dim)
     actual = _sequential_gamma_gaussian_tensordot(g)
@@ -127,6 +130,7 @@ def test_sequential_gamma_gaussian_tensordot(batch_shape, state_dim, num_steps):
     (False, (3,), (7,), (4, 7)),
     (False, (), (3, 7), (4, 7)),
 ], ids=str)
+@skipif_rocm
 def test_discrete_hmm_shape(ok, init_shape, trans_shape, obs_shape, event_shape, state_dim):
     init_logits = torch.randn(init_shape + (state_dim,))
     trans_logits = torch.randn(trans_shape + (state_dim, state_dim))
@@ -272,6 +276,7 @@ def test_discrete_hmm_diag_normal(num_steps):
     ((5,), (5, 6), (5, 6), (5, 6), (5, 6)),
 ], ids=str)
 @pytest.mark.parametrize("diag", [False, True], ids=["full", "diag"])
+@skipif_rocm
 def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
                             obs_mat_shape, obs_mvn_shape, hidden_dim, obs_dim):
     init_dist = random_mvn(init_shape, hidden_dim)
@@ -334,6 +339,7 @@ def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
         assert d2.event_shape == (f, obs_dim)
 
 
+@skipif_rocm
 def test_gaussian_hmm_high_obs_dim():
     hidden_dim = 1
     obs_dim = 1000
@@ -358,6 +364,7 @@ def test_gaussian_hmm_high_obs_dim():
 @pytest.mark.parametrize('hidden_dim', [1, 2])
 @pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
 @pytest.mark.parametrize("diag", [False, True], ids=["full", "diag"])
+@skipif_rocm
 def test_gaussian_hmm_distribution(diag, sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim))
@@ -466,6 +473,7 @@ def test_gaussian_hmm_distribution(diag, sample_shape, batch_shape, num_steps, h
     ((11,), (11, 7), (11, 7)),
     ((4, 1, 1), (3, 1, 7), (2, 7)),
 ], ids=str)
+@skipif_rocm
 def test_gaussian_mrf_shape(init_shape, trans_shape, obs_shape, hidden_dim, obs_dim):
     init_dist = random_mvn(init_shape, hidden_dim)
     trans_dist = random_mvn(trans_shape, hidden_dim + hidden_dim)
@@ -490,6 +498,7 @@ def test_gaussian_mrf_shape(init_shape, trans_shape, obs_shape, hidden_dim, obs_
 @pytest.mark.parametrize('obs_dim', [1, 2])
 @pytest.mark.parametrize('hidden_dim', [1, 2])
 @pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
+@skipif_rocm
 def test_gaussian_mrf_log_prob(sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + hidden_dim)
@@ -541,6 +550,7 @@ def test_gaussian_mrf_log_prob(sample_shape, batch_shape, num_steps, hidden_dim,
 @pytest.mark.parametrize('obs_dim', [1, 2])
 @pytest.mark.parametrize('hidden_dim', [1, 2])
 @pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
+@skipif_rocm
 def test_gaussian_mrf_log_prob_block_diag(sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
     # Construct a block-diagonal obs dist, so observations are independent of hidden state.
     obs_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + obs_dim)
@@ -581,6 +591,7 @@ def test_gaussian_mrf_log_prob_block_diag(sample_shape, batch_shape, num_steps, 
     ((), (5,), (), (), (), (6,)),
     ((5,), (5,), (5, 6), (5, 6), (5, 6), (5, 6)),
 ], ids=str)
+@skipif_rocm
 def test_gamma_gaussian_hmm_shape(scale_shape, init_shape, trans_mat_shape, trans_mvn_shape,
                                   obs_mat_shape, obs_mvn_shape, hidden_dim, obs_dim):
     init_dist = random_mvn(init_shape, hidden_dim)
@@ -622,6 +633,7 @@ def test_gamma_gaussian_hmm_shape(scale_shape, init_shape, trans_mat_shape, tran
 @pytest.mark.parametrize('obs_dim', [1, 2])
 @pytest.mark.parametrize('hidden_dim', [1, 2])
 @pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
+@skipif_rocm
 def test_gamma_gaussian_hmm_log_prob(sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim))
@@ -798,6 +810,7 @@ def test_studentt_hmm_shape(init_shape, trans_mat_shape, trans_dist_shape,
     ((5,), (), (), (), (6,)),
     ((5,), (5, 6), (5, 6), (5, 6), (5, 6)),
 ], ids=str)
+@skipif_rocm
 def test_independent_hmm_shape(init_shape, trans_mat_shape, trans_mvn_shape,
                                obs_mat_shape, obs_mvn_shape, hidden_dim, obs_dim):
     base_init_shape = init_shape + (obs_dim,)

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -7,7 +7,7 @@ from torch.distributions.utils import _sum_rightmost
 
 import pyro.distributions as dist
 from pyro.util import torch_isnan
-from tests.common import assert_equal, rocm_env
+from tests.common import assert_equal, rocm_env, skipif_rocm
 
 
 @pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
@@ -90,6 +90,7 @@ def test_to_event(base_dist):
 @pytest.mark.parametrize('event_shape', [(), (2,), (2, 3)])
 @pytest.mark.parametrize('batch_shape', [(), (3,), (5, 3)])
 @pytest.mark.parametrize('sample_shape', [(), (2,), (4, 2)])
+@skipif_rocm
 def test_expand(sample_shape, batch_shape, event_shape):
     ones_shape = torch.Size((1,) * len(batch_shape))
     zero = torch.zeros(ones_shape + event_shape)

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -7,16 +7,17 @@ from torch.distributions.utils import _sum_rightmost
 
 import pyro.distributions as dist
 from pyro.util import torch_isnan
-from tests.common import assert_equal
+from tests.common import assert_equal, rocm_env
 
 
 @pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
 @pytest.mark.parametrize('batch_shape', [(), (7,), (5, 3), (5, 3, 2)])
 @pytest.mark.parametrize('reinterpreted_batch_ndims', [0, 1, 2, 3])
 @pytest.mark.parametrize('base_dist',
+                         [dist.Normal(1., 2.), dist.Exponential(2.)] if rocm_env else
                          [dist.Normal(1., 2.), dist.Exponential(2.),
                           dist.MultivariateNormal(torch.zeros(2), torch.eye(2))],
-                         ids=['normal', 'exponential', 'mvn'])
+                         ids=['normal', 'exponential'] if rocm_env else ['normal', 'exponential', 'mvn'])
 def test_independent(base_dist, sample_shape, batch_shape, reinterpreted_batch_ndims):
     if batch_shape:
         base_dist = base_dist.expand_by(batch_shape)
@@ -42,9 +43,10 @@ def test_independent(base_dist, sample_shape, batch_shape, reinterpreted_batch_n
 
 
 @pytest.mark.parametrize('base_dist',
+                         [dist.Normal(1., 2.), dist.Exponential(2.)] if rocm_env else
                          [dist.Normal(1., 2.), dist.Exponential(2.),
                           dist.MultivariateNormal(torch.zeros(2), torch.eye(2))],
-                         ids=['normal', 'exponential', 'mvn'])
+                         ids=['normal', 'exponential'] if rocm_env else ['normal', 'exponential', 'mvn'])
 def test_to_event(base_dist):
     base_dist = base_dist.expand([2, 3])
     d = base_dist

--- a/tests/distributions/test_kl.py
+++ b/tests/distributions/test_kl.py
@@ -7,7 +7,7 @@ from torch.distributions import kl_divergence, transforms
 
 import pyro.distributions as dist
 from pyro.distributions.util import sum_rightmost
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm
 
 
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
@@ -22,6 +22,7 @@ def test_kl_delta_normal_shape(batch_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize('size', [1, 2, 3])
+@skipif_rocm
 def test_kl_delta_mvn_shape(batch_shape, size):
     v = torch.randn(batch_shape + (size,))
     p = dist.Delta(v, event_dim=1)
@@ -47,6 +48,7 @@ def test_kl_independent_normal(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize('size', [1, 2, 3])
+@skipif_rocm
 def test_kl_independent_delta_mvn_shape(batch_shape, size):
     v = torch.randn(batch_shape + (size,))
     p = dist.Independent(dist.Delta(v), 1)
@@ -60,6 +62,7 @@ def test_kl_independent_delta_mvn_shape(batch_shape, size):
 
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize('size', [1, 2, 3])
+@skipif_rocm
 def test_kl_independent_normal_mvn(batch_shape, size):
     loc = torch.randn(batch_shape + (size,))
     scale = torch.randn(batch_shape + (size,)).exp()

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -9,7 +9,7 @@ from torch.distributions import AffineTransform, Beta, TransformedDistribution, 
 
 from pyro.distributions import constraints, transforms
 from pyro.distributions.lkj import LKJCorrCholesky
-from tests.common import assert_equal, assert_tensors_equal
+from tests.common import assert_equal, assert_tensors_equal, skipif_rocm
 
 
 @pytest.mark.parametrize("value_shape", [(1, 1), (3, 3), (5, 5)])
@@ -28,6 +28,7 @@ def _autograd_log_det(ys, x):
 
 
 @pytest.mark.parametrize("y_shape", [(1,), (3, 1), (6,), (1, 6), (2, 6)])
+@skipif_rocm
 def test_unconstrained_to_corr_cholesky_transform(y_shape):
     transform = transforms.CorrLCholeskyTransform()
     y = torch.empty(y_shape).uniform_(-4, 4).requires_grad_()

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -4,9 +4,10 @@
 import torch
 
 from pyro.distributions import LowRankMultivariateNormal, MultivariateNormal
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
+@skipif_rocm
 def test_scale_tril():
     loc = torch.tensor([1.0, 2.0, 1.0, 2.0, 0.0])
     D = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
@@ -19,6 +20,7 @@ def test_scale_tril():
     assert_equal(mvn.scale_tril, lowrank_mvn.scale_tril)
 
 
+@skipif_rocm
 def test_log_prob():
     loc = torch.tensor([2.0, 1.0, 1.0, 2.0, 2.0])
     D = torch.tensor([1.0, 2.0, 3.0, 1.0, 3.0])
@@ -32,6 +34,7 @@ def test_log_prob():
     assert_equal(mvn.log_prob(x), lowrank_mvn.log_prob(x))
 
 
+@skipif_rocm
 def test_variance():
     loc = torch.tensor([1.0, 1.0, 1.0, 2.0, 0.0])
     D = torch.tensor([1.0, 2.0, 2.0, 4.0, 5.0])

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -7,7 +7,7 @@ import torch
 import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
 from pyro.util import torch_isnan
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 @pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
@@ -45,6 +45,7 @@ def test_masked_mixture_univariate(component0, component1, sample_shape, batch_s
 
 @pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
 @pytest.mark.parametrize('batch_shape', [(), (7,), (5, 3)])
+@skipif_rocm
 def test_masked_mixture_multivariate(sample_shape, batch_shape):
     event_shape = torch.Size((8,))
     component0 = dist.MultivariateNormal(torch.zeros(event_shape), torch.eye(event_shape[0]))

--- a/tests/distributions/test_mvn.py
+++ b/tests/distributions/test_mvn.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.distributions import MultivariateNormal
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 def random_mvn(loc_shape, cov_shape, dim):
@@ -28,6 +28,7 @@ def random_mvn(loc_shape, cov_shape, dim):
 @pytest.mark.parametrize('dim', [
     1, 3, 5,
 ])
+@skipif_rocm
 def test_shape(loc_shape, cov_shape, dim):
     mvn = random_mvn(loc_shape, cov_shape, dim)
     assert mvn.loc.shape == mvn.batch_shape + mvn.event_shape

--- a/tests/distributions/test_mvt.py
+++ b/tests/distributions/test_mvt.py
@@ -9,7 +9,7 @@ import torch
 from torch.distributions import Gamma, MultivariateNormal, StudentT
 
 from pyro.distributions import MultivariateStudentT
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 def random_mvt(df_shape, loc_shape, cov_shape, dim):
@@ -37,6 +37,7 @@ def random_mvt(df_shape, loc_shape, cov_shape, dim):
 @pytest.mark.parametrize('dim', [
     1, 3, 5,
 ])
+@skipif_rocm
 def test_shape(df_shape, loc_shape, cov_shape, dim):
     mvt = random_mvt(df_shape, loc_shape, cov_shape, dim)
     assert mvt.df.shape == mvt.batch_shape
@@ -57,6 +58,7 @@ def test_shape(df_shape, loc_shape, cov_shape, dim):
     (4,),
 ], ids=str)
 @pytest.mark.parametrize("dim", [1, 2])
+@skipif_rocm
 def test_log_prob(batch_shape, dim):
     loc = torch.randn(batch_shape + (dim,))
     A = torch.randn(batch_shape + (dim, dim + dim))
@@ -80,6 +82,7 @@ def test_log_prob(batch_shape, dim):
 
 @pytest.mark.parametrize("df", [3.9, 9.1])
 @pytest.mark.parametrize("dim", [1, 2])
+@skipif_rocm
 def test_rsample(dim, df, num_samples=200 * 1000):
     scale_tril = (0.5 * torch.randn(dim)).exp().diag() + 0.1 * torch.randn(dim, dim)
     scale_tril = scale_tril.tril(0)
@@ -101,6 +104,7 @@ def test_rsample(dim, df, num_samples=200 * 1000):
 
 
 @pytest.mark.parametrize("dim", [1, 2])
+@skipif_rocm
 def test_log_prob_normalization(dim, df=6.1, grid_size=2000, domain_width=5.0):
     scale_tril = (0.2 * torch.randn(dim) - 1.5).exp().diag() + 0.1 * torch.randn(dim, dim)
     scale_tril = 0.1 * scale_tril.tril(0)
@@ -125,6 +129,7 @@ def test_log_prob_normalization(dim, df=6.1, grid_size=2000, domain_width=5.0):
     (3, 2),
     (4,),
 ], ids=str)
+@skipif_rocm
 def test_mean_var(batch_shape):
     dim = 2
     loc = torch.randn(batch_shape + (dim,))

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -6,7 +6,7 @@ import torch
 
 import pytest
 from pyro.distributions import AVFMultivariateNormal, MultivariateNormal, OMTMultivariateNormal
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 def analytic_grad(L11=1.0, L22=1.0, L21=1.0, omega1=1.0, omega2=1.0):
@@ -23,6 +23,7 @@ def analytic_grad(L11=1.0, L22=1.0, L21=1.0, omega1=1.0, omega2=1.0):
 @pytest.mark.parametrize('sample_shape', [torch.Size([1000, 2000]), torch.Size([200000])])
 @pytest.mark.parametrize('k', [1])
 @pytest.mark.parametrize('mvn_dist', ['OMTMultivariateNormal', 'AVFMultivariateNormal'])
+@skipif_rocm
 def test_mean_gradient(mvn_dist, k, sample_shape, L21, omega1, L11, L22=0.8, L33=0.9, omega2=0.75):
     if mvn_dist == 'OMTMultivariateNormal' and k > 1:
         return
@@ -58,6 +59,7 @@ def test_mean_gradient(mvn_dist, k, sample_shape, L21, omega1, L11, L22=0.8, L33
 @pytest.mark.parametrize('omega1', [0.5, 0.9])
 @pytest.mark.parametrize('k', [3])
 @pytest.mark.parametrize('mvn_dist', ['OMTMultivariateNormal', 'AVFMultivariateNormal'])
+@skipif_rocm
 def test_mean_single_gradient(mvn_dist, k, L21, omega1, L11, L22=0.8, L33=0.9, omega2=0.75, n_samples=20000):
     omega = torch.tensor([omega1, omega2, 0.0])
     loc = torch.zeros(3, requires_grad=True)
@@ -92,6 +94,7 @@ def test_mean_single_gradient(mvn_dist, k, L21, omega1, L11, L22=0.8, L33=0.9, o
 
 
 @pytest.mark.parametrize('mvn_dist', [OMTMultivariateNormal, AVFMultivariateNormal])
+@skipif_rocm
 def test_log_prob(mvn_dist):
     loc = torch.tensor([2.0, 1.0, 1.0, 2.0, 2.0])
     D = torch.tensor([1.0, 2.0, 3.0, 1.0, 3.0])

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -9,7 +9,7 @@ from pyro.distributions import Exponential, Gamma
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
 from pyro.distributions.testing.rejection_gamma import (RejectionGamma, RejectionStandardGamma, ShapeAugmentedBeta,
                                                         ShapeAugmentedGamma)
-from tests.common import assert_equal
+from tests.common import assert_equal, rocm_env
 
 SIZES = list(map(torch.Size, [[], [1], [2], [3], [1, 1], [1, 2], [2, 3, 4]]))
 
@@ -79,6 +79,7 @@ def test_exponential_elbo(rate, factor):
 
 
 @pytest.mark.parametrize('alpha', [1.0, 2.0, 5.0])
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_standard_gamma_elbo(alpha):
     num_samples = 100000
     alphas = torch.full((num_samples, 1), alpha).requires_grad_()

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -11,7 +11,7 @@ import pyro.optim as optim
 from pyro.distributions import (OneHotCategorical, RelaxedBernoulli, RelaxedBernoulliStraightThrough,
                                 RelaxedOneHotCategorical, RelaxedOneHotCategoricalStraightThrough)
 from pyro.infer import SVI, Trace_ELBO
-from tests.common import assert_equal
+from tests.common import assert_equal, rocm_env
 
 ONEHOT_PROBS = [
                 [0.25, 0.75],
@@ -57,6 +57,7 @@ def test_onehot_entropy_grad(temp):
                  format(expected, actual))
 
 
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_onehot_svi_usage():
 
     def model():

--- a/tests/distributions/test_stable.py
+++ b/tests/distributions/test_stable.py
@@ -42,7 +42,7 @@ def test_sample(alpha, beta):
         try:
             old = pyro.distributions.stable.RADIUS
             pyro.distributions.stable.RADIUS = 0.02
-            return d.sample([size])
+            return d.sample([size]).cpu()
         finally:
             pyro.distributions.stable.RADIUS = old
 
@@ -77,7 +77,7 @@ def test_sample_2(alpha, beta):
         actual = d.sample([num_samples])
     finally:
         pyro.distributions.stable.RADIUS = old
-    actual = d.sample([num_samples])
+    actual = d.sample([num_samples]).cpu()
 
     expected = levy_stable.rvs(alpha, beta, size=num_samples)
 
@@ -110,7 +110,7 @@ def test_additive(stability, skew0, skew1, scale0, scale1):
     d = dist.Stable(stability, skew, scale, coords="S")
     actual = d.sample([num_samples])
 
-    assert ks_2samp(expected, actual).pvalue > 0.05
+    assert ks_2samp(expected.cpu(), actual.cpu()).pvalue > 0.05
 
 
 @pytest.mark.parametrize("scale", [0.5, 1.5])

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -6,7 +6,7 @@ import scipy.stats as sp
 import torch
 
 import pyro.distributions as dist
-from tests.common import assert_equal
+from tests.common import assert_equal, rocm_env
 
 
 @pytest.fixture()
@@ -67,6 +67,7 @@ def test_float_type(float_test_data, float_alpha, float_beta, test_data, alpha, 
     assert_equal(log_px_val, log_px_np, prec=1e-4)
 
 
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_conflicting_types(test_data, float_alpha, beta):
     with pytest.raises((TypeError, RuntimeError)):
         dist.Beta(float_alpha, beta).log_prob(test_data)

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 import pyro.distributions as dist
-from tests.common import assert_close, requires_cuda
+from tests.common import assert_close, requires_cuda, skipif_rocm
 
 
 @requires_cuda
@@ -22,6 +22,7 @@ def test_linspace():
 
 @pytest.mark.parametrize("batch_shape", [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
+@skipif_rocm
 def test_lower_cholesky_transform(batch_shape, dim):
     t = torch.distributions.transform_to(torch.distributions.constraints.lower_cholesky)
     x = torch.randn(batch_shape + (dim, dim))

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -8,6 +8,7 @@ import torch
 
 import pyro.distributions as dist
 import pyro.distributions.transforms as T
+from tests.common import skipif_rocm
 
 from functools import partial, reduce
 import operator
@@ -140,10 +141,12 @@ class TransformTests(TestCase):
         for stable in [True, False]:
             self._test(partial(T.affine_autoregressive, stable=stable))
 
+    @skipif_rocm
     def test_affine_coupling(self):
         for dim in [-1, -2]:
             self._test(partial(T.affine_coupling, dim=dim), event_dim=-dim)
 
+    @skipif_rocm
     def test_batchnorm(self):
         # Need to make moving average statistics non-zeros/ones and set to eval so inverse is valid
         # (see the docs about the differing behaviour of BatchNorm in train and eval modes)
@@ -165,10 +168,12 @@ class TransformTests(TestCase):
     def test_conditional_affine_autoregressive(self):
         self._test_conditional(T.conditional_affine_autoregressive)
 
+    @skipif_rocm
     def test_conditional_affine_coupling(self):
         for dim in [-1, -2]:
             self._test_conditional(partial(T.conditional_affine_coupling, dim=dim), event_dim=-dim)
 
+    @skipif_rocm
     def test_conditional_generalized_channel_permute(self, context_dim=3):
         for shape in [(3, 16, 16), (1, 3, 32, 32), (2, 5, 3, 64, 64)]:
             # NOTE: Without changing the interface to generalized_channel_permute I can't reuse general
@@ -182,6 +187,7 @@ class TransformTests(TestCase):
             input_dim = (width_dim**2) * 3
             self._test_jacobian(input_dim, Flatten(transform, (3, width_dim, width_dim)))
 
+    @skipif_rocm
     def test_conditional_householder(self):
         self._test_conditional(T.conditional_householder)
         self._test_conditional(partial(T.conditional_householder, count_transforms=2))
@@ -189,12 +195,15 @@ class TransformTests(TestCase):
     def test_conditional_neural_autoregressive(self):
         self._test_conditional(T.conditional_neural_autoregressive, inverse=False)
 
+    @skipif_rocm
     def test_conditional_planar(self):
         self._test_conditional(T.conditional_planar, inverse=False)
 
+    @skipif_rocm
     def test_conditional_radial(self):
         self._test_conditional(T.conditional_radial, inverse=False)
 
+    @skipif_rocm
     def test_discrete_cosine(self):
         # NOTE: Need following since helper function unimplemented
         self._test(lambda input_dim: T.DiscreteCosineTransform())
@@ -202,15 +211,18 @@ class TransformTests(TestCase):
         self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=1.0))
         self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=2.0))
 
+    @skipif_rocm
     def test_haar_transform(self):
         # NOTE: Need following since helper function unimplemented
         self._test(lambda input_dim: T.HaarTransform(flip=True))
         self._test(lambda input_dim: T.HaarTransform(flip=False))
 
+    @skipif_rocm
     def test_elu(self):
         # NOTE: Need following since helper function mistakenly doesn't take input dim
         self._test(lambda input_dim: T.elu())
 
+    @skipif_rocm
     def test_generalized_channel_permute(self):
         for shape in [(3, 16, 16), (1, 3, 32, 32), (2, 5, 3, 64, 64)]:
             # NOTE: Without changing the interface to generalized_channel_permute I can't reuse general
@@ -223,13 +235,16 @@ class TransformTests(TestCase):
             input_dim = (width_dim**2) * 3
             self._test_jacobian(input_dim, Flatten(transform, (3, width_dim, width_dim)))
 
+    @skipif_rocm
     def test_householder(self):
         self._test(partial(T.householder, count_transforms=2))
 
+    @skipif_rocm
     def test_leaky_relu(self):
         # NOTE: Need following since helper function mistakenly doesn't take input dim
         self._test(lambda input_dim: T.leaky_relu())
 
+    @skipif_rocm
     def test_lower_cholesky_affine(self):
         # NOTE: Need following since helper function unimplemented
         def transform_factory(input_dim):
@@ -240,25 +255,32 @@ class TransformTests(TestCase):
 
         self._test(transform_factory)
 
+    @skipif_rocm
     def test_neural_autoregressive(self):
         for activation in ['ELU', 'LeakyReLU', 'sigmoid', 'tanh']:
             self._test(partial(T.neural_autoregressive, activation=activation), inverse=False)
 
+    @skipif_rocm
     def test_permute(self):
         for dim in [-1, -2]:
             self._test(partial(T.permute, dim=dim), event_dim=-dim)
 
+    @skipif_rocm
     def test_planar(self):
         self._test(T.planar, inverse=False)
 
+    @skipif_rocm
     def test_polynomial(self):
         self._test(T.polynomial, inverse=False)
 
+    @skipif_rocm
     def test_radial(self):
         self._test(T.radial, inverse=False)
 
+    @skipif_rocm
     def test_spline(self):
         self._test(T.spline)
 
+    @skipif_rocm
     def test_sylvester(self):
         self._test(T.sylvester, inverse=False)

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -9,7 +9,7 @@ import torch
 from torch import optim
 
 from pyro.distributions import VonMises, VonMises3D
-from tests.common import skipif_param
+from tests.common import skipif_param, rocm_env
 
 
 def _eval_poly(y, coef):
@@ -108,6 +108,7 @@ def test_log_prob_normalized(concentration):
 
 
 @pytest.mark.parametrize('scale', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_von_mises_3d(scale):
     concentration = torch.randn(3)
     concentration = concentration * (scale / concentration.norm(2))

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -10,7 +10,7 @@ from pyro.infer.mcmc.adaptation import (
     WarmupAdapter,
     adapt_window,
 )
-from tests.common import assert_close, assert_equal
+from tests.common import assert_close, assert_equal, skipif_rocm
 
 
 @pytest.mark.parametrize("adapt_step_size, adapt_mass, warmup_steps, expected", [
@@ -21,6 +21,7 @@ from tests.common import assert_close, assert_equal
     (True, True, 280, [(0, 74), (75, 99), (100, 229), (230, 279)]),
     (True, True, 18, [(0, 17)]),
 ])
+@skipif_rocm
 def test_adaptation_schedule(adapt_step_size, adapt_mass, warmup_steps, expected):
     adapter = WarmupAdapter(0.1,
                             adapt_step_size=adapt_step_size,
@@ -31,6 +32,7 @@ def test_adaptation_schedule(adapt_step_size, adapt_mass, warmup_steps, expected
 
 
 @pytest.mark.parametrize("diagonal", [True, False])
+@skipif_rocm
 def test_arrowhead_mass_matrix(diagonal):
     shape = (2, 3)
     num_samples = 1000

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -13,7 +13,7 @@ import pyro.distributions as dist
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
-from tests.common import assert_equal, assert_close
+from tests.common import assert_equal, assert_close, rocm_env, skipif_rocm
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +171,7 @@ def test_hmc_conjugate_gaussian(fixture,
         (None, 1, None, True, True, True),
     ]
 )
+@pytest.mark.skipif(condition=rocm_env, reason="test fails on ROCm")
 def test_logistic_regression(step_size, trajectory_length, num_steps,
                              adapt_step_size, adapt_mass_matrix, full_mass):
     dim = 3
@@ -304,6 +305,7 @@ def test_unnormalized_normal(kernel, jit):
 
 @pytest.mark.parametrize('jit', [False, mark_jit(True)], ids=jit_idfn)
 @pytest.mark.parametrize('op', [torch.inverse, torch.cholesky])
+@skipif_rocm
 def test_singular_matrix_catch(jit, op):
     def potential_energy(z):
         return op(z['cov']).sum()

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -17,7 +17,7 @@ from pyro.infer.mcmc import ArrowheadMassMatrix, MCMC, NUTS
 import pyro.optim as optim
 import pyro.poutine as poutine
 from pyro.util import ignore_jit_warnings
-from tests.common import assert_close, assert_equal
+from tests.common import assert_close, assert_equal, skipif_rocm, rocm_env, skip_param_rocm
 
 from .test_hmc import GaussianChain, rmse
 
@@ -134,6 +134,7 @@ def test_nuts_conjugate_gaussian(fixture,
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
 @pytest.mark.parametrize("use_multinomial_sampling", [True, False])
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_logistic_regression(jit, use_multinomial_sampling):
     dim = 3
     data = torch.randn(2000, dim)
@@ -163,7 +164,7 @@ def test_logistic_regression(jit, use_multinomial_sampling):
         (0.5, False, True, False),
         (None, True, False, False),
         (None, True, True, False),
-        (None, True, True, True),
+        skip_param_rocm(None, True, True, True),
     ]
 )
 def test_beta_bernoulli(step_size, adapt_step_size, adapt_mass_matrix, full_mass):
@@ -360,6 +361,7 @@ def test_beta_binomial(hyperpriors):
 
 
 @pytest.mark.parametrize("hyperpriors", [False, True])
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_gamma_poisson(hyperpriors):
     def model(data):
         with pyro.plate("latent_dim", data.shape[1]):
@@ -381,6 +383,7 @@ def test_gamma_poisson(hyperpriors):
     assert_equal(posterior["rate"].mean(0), true_rate, prec=0.3)
 
 
+@skipif_rocm
 def test_structured_mass():
     def model(cov):
         w = pyro.sample("w", dist.Normal(0, 1000).expand([2]).to_event(1))
@@ -413,6 +416,7 @@ def test_structured_mass():
     assert_close(kernel.inverse_mass_matrix[("z",)], z_var, atol=0.5, rtol=0.5)
 
 
+@skipif_rocm
 def test_arrowhead_mass():
     def model(prec):
         w = pyro.sample("w", dist.Normal(0, 1000).expand([2]).to_event(1))

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -12,7 +12,7 @@ from pyro.infer.autoguide import AutoDiagonalNormal
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.reparam import ConjugateReparam, LinearHMMReparam, StableReparam
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm, rocm_env
 from tests.ops.gaussian import random_mvn
 
 
@@ -65,6 +65,7 @@ def test_beta_binomial_dependent_sample():
     assert_close(samples.std(), posterior.variance.sqrt(), atol=0.01)
 
 
+@pytest.mark.skipif(rocm_env, reason="nan in output on ROCm")
 def test_beta_binomial_elbo():
     total = 10
     counts = dist.Binomial(total, 0.3).sample()
@@ -102,6 +103,7 @@ def test_beta_binomial_elbo():
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("hidden_dim,obs_dim", [(1, 1), (3, 2)], ids=str)
 @pytest.mark.parametrize("num_steps", range(1, 6))
+@skipif_rocm
 def test_gaussian_hmm_elbo(batch_shape, num_steps, hidden_dim, obs_dim):
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim), requires_grad=True)
@@ -152,6 +154,7 @@ def random_stable(shape):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("hidden_dim,obs_dim", [(1, 1), (2, 3)], ids=str)
 @pytest.mark.parametrize("num_steps", range(1, 6))
+@skipif_rocm
 def test_stable_hmm_smoke(batch_shape, num_steps, hidden_dim, obs_dim):
     init_dist = random_stable(batch_shape + (hidden_dim,)).to_event(1)
     trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim), requires_grad=True)

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -8,7 +8,7 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer.reparam import LinearHMMReparam, StableReparam, StudentTReparam, SymmetricStableReparam
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm, skip_param_rocm
 from tests.ops.gaussian import random_mvn
 
 
@@ -31,6 +31,7 @@ def random_stable(shape, stability, skew=None):
 @pytest.mark.parametrize("obs_dim", [1, 2])
 @pytest.mark.parametrize("hidden_dim", [1, 3])
 @pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
+@skipif_rocm
 def test_transformed_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_mat = torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
@@ -56,7 +57,7 @@ def test_transformed_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
 
 @pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])
 @pytest.mark.parametrize("obs_dim", [1, 2])
-@pytest.mark.parametrize("hidden_dim", [1, 3])
+@pytest.mark.parametrize("hidden_dim", [1, skip_param_rocm(3)])
 @pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
 def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     init_dist = random_studentt(batch_shape + (hidden_dim,)).to_event(1)
@@ -85,7 +86,7 @@ def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
 
 @pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])
 @pytest.mark.parametrize("obs_dim", [1, 2])
-@pytest.mark.parametrize("hidden_dim", [1, 3])
+@pytest.mark.parametrize("hidden_dim", [1, skip_param_rocm(3)])
 @pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
 def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
@@ -117,7 +118,7 @@ def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
 
 @pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])
 @pytest.mark.parametrize("obs_dim", [1, 2])
-@pytest.mark.parametrize("hidden_dim", [1, 3])
+@pytest.mark.parametrize("hidden_dim", [1, skip_param_rocm(3)])
 @pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
 def test_independent_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
@@ -169,6 +170,7 @@ def get_hmm_moments(samples):
 @pytest.mark.parametrize("hidden_dim", [1, 2])
 @pytest.mark.parametrize("stability", [1.9, 1.6])
 @pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
+@skipif_rocm
 def test_stable_hmm_distribution(stability, skew, duration, hidden_dim, obs_dim):
     init_dist = random_stable((hidden_dim,), stability, skew=skew).to_event(1)
     trans_mat = torch.randn(duration, hidden_dim, hidden_dim)

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -113,7 +113,7 @@ def test_distribution(stability, skew, Reparam):
     expected = model()
     with poutine.reparam(config={"x": Reparam()}):
         actual = model()
-    assert ks_2samp(expected, actual).pvalue > 0.05
+    assert ks_2samp(expected.cpu(), actual.cpu()).pvalue > 0.05
 
 
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -13,7 +13,7 @@ from pyro.distributions.torch_distribution import MaskedDistribution
 from pyro.infer import Trace_ELBO
 from pyro.infer.autoguide import AutoNormal
 from pyro.infer.reparam import LatentStableReparam, StableReparam, SymmetricStableReparam
-from tests.common import assert_close
+from tests.common import assert_close, rocm_env
 
 
 # Test helper to extract a few absolute moments from univariate samples.
@@ -26,6 +26,7 @@ def get_moments(x):
 
 @pytest.mark.parametrize("shape", [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize("Reparam", [LatentStableReparam, StableReparam])
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_stable(Reparam, shape):
     stability = torch.empty(shape).uniform_(1.5, 2.).requires_grad_()
     skew = torch.empty(shape).uniform_(-0.5, 0.5).requires_grad_()
@@ -67,6 +68,7 @@ def test_stable(Reparam, shape):
 
 
 @pytest.mark.parametrize("shape", [(), (4,), (2, 3)], ids=str)
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_symmetric_stable(shape):
     stability = torch.empty(shape).uniform_(1.6, 1.9).requires_grad_()
     scale = torch.empty(shape).uniform_(0.5, 1.0).requires_grad_()

--- a/tests/infer/reparam/test_studentt.py
+++ b/tests/infer/reparam/test_studentt.py
@@ -64,4 +64,4 @@ def test_distribution(df, loc, scale):
     expected = model()
     with poutine.reparam(config={"x": StudentTReparam()}):
         actual = model()
-    assert ks_2samp(expected, actual).pvalue > 0.05
+    assert ks_2samp(expected.cpu(), actual.cpu()).pvalue > 0.05

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -11,7 +11,7 @@ import pyro.poutine as poutine
 from pyro.infer.autoguide import AutoLaplaceApproximation
 from pyro.infer import SVI, Trace_ELBO
 from pyro.infer.mcmc import MCMC, NUTS
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
@@ -43,6 +43,7 @@ def test_nesting():
 
 # TODO: Make this available directly in `SVI` if needed.
 @pytest.mark.filterwarnings('ignore::FutureWarning')
+@skipif_rocm
 def test_information_criterion():
     # milk dataset: https://github.com/rmcelreath/rethinking/blob/master/data/milk.csv
     kcal = torch.tensor([0.49, 0.47, 0.56, 0.89, 0.92, 0.8, 0.46, 0.71, 0.68,

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -25,14 +25,14 @@ from pyro.nn.module import PyroModule, PyroParam, PyroSample
 from pyro.optim import Adam
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match
-from tests.common import assert_close, assert_equal
+from tests.common import assert_close, assert_equal, skip_param_rocm, skipif_rocm
 
 
 @pytest.mark.parametrize("auto_class", [
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
     AutoIAFNormal,
 ])
 def test_scores(auto_class):
@@ -61,9 +61,9 @@ def test_scores(auto_class):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
     AutoIAFNormal,
     AutoLaplaceApproximation,
 ])
@@ -105,6 +105,7 @@ def test_factor(auto_class, Elbo):
     AutoLaplaceApproximation,
 ])
 @pytest.mark.filterwarnings("ignore::FutureWarning")
+@skipif_rocm
 def test_shapes(auto_class, init_loc_fn, Elbo):
 
     def model():
@@ -206,10 +207,10 @@ def nested_auto_guide_callable(model):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
-    AutoLaplaceApproximation,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
+    skip_param_rocm(AutoLaplaceApproximation),
     auto_guide_list_x,
     auto_guide_callable,
     auto_guide_module_callable,
@@ -249,10 +250,10 @@ def test_median(auto_class, Elbo):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
-    AutoLaplaceApproximation,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
+    skip_param_rocm(AutoLaplaceApproximation),
     auto_guide_list_x,
     auto_guide_module_callable,
     nested_auto_guide_callable,
@@ -305,10 +306,10 @@ def test_autoguide_serialization(auto_class, Elbo):
 
 @pytest.mark.parametrize("auto_class", [
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
-    AutoLaplaceApproximation,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
+    skip_param_rocm(AutoLaplaceApproximation),
 ])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_quantiles(auto_class, Elbo):
@@ -354,11 +355,11 @@ def test_quantiles(auto_class, Elbo):
 @pytest.mark.parametrize("continuous_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
     AutoIAFNormal,
-    AutoLaplaceApproximation,
+    skip_param_rocm(AutoLaplaceApproximation),
 ])
 def test_discrete_parallel(continuous_class):
     K = 2
@@ -392,6 +393,7 @@ def test_discrete_parallel(continuous_class):
     AutoIAFNormal,
     AutoLaplaceApproximation,
 ])
+@skipif_rocm
 def test_guide_list(auto_class):
 
     def model():
@@ -412,6 +414,7 @@ def test_guide_list(auto_class):
     AutoLowRankMultivariateNormal,
     AutoLaplaceApproximation,
 ])
+@skipif_rocm
 def test_callable(auto_class):
 
     def model():
@@ -437,6 +440,7 @@ def test_callable(auto_class):
     AutoLowRankMultivariateNormal,
     AutoLaplaceApproximation,
 ])
+@skipif_rocm
 def test_callable_return_dict(auto_class):
 
     def model():
@@ -479,6 +483,7 @@ def test_unpack_latent():
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
 ])
+@skipif_rocm
 def test_init_loc_fn(auto_class):
 
     def model():
@@ -510,6 +515,7 @@ class AutoLowRankMultivariateNormal_100(AutoLowRankMultivariateNormal):
     AutoLowRankMultivariateNormal,
     AutoLowRankMultivariateNormal_100,
 ])
+@skipif_rocm
 def test_init_scale(auto_class, init_scale):
 
     def model():
@@ -528,9 +534,9 @@ def test_init_scale(auto_class, init_scale):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
-    AutoLowRankMultivariateNormal,
-    AutoLaplaceApproximation,
+    skip_param_rocm(AutoMultivariateNormal),
+    skip_param_rocm(AutoLowRankMultivariateNormal),
+    skip_param_rocm(AutoLaplaceApproximation),
     auto_guide_list_x,
     auto_guide_callable,
     auto_guide_module_callable,
@@ -606,9 +612,9 @@ def test_nested_autoguide(Elbo):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
     AutoLaplaceApproximation,
     functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_mean),
     functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_median),
@@ -644,9 +650,9 @@ def test_linear_regression_smoke(auto_class, Elbo):
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
-    AutoMultivariateNormal,
+    skip_param_rocm(AutoMultivariateNormal),
     AutoNormal,
-    AutoLowRankMultivariateNormal,
+    skip_param_rocm(AutoLowRankMultivariateNormal),
     AutoLaplaceApproximation,
     functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_mean),
     functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_median),

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -26,7 +26,7 @@ from pyro.infer.traceenum_elbo import TraceEnum_ELBO
 from pyro.infer.util import LAST_CACHE_SIZE
 from pyro.ops.indexing import Vindex
 from pyro.util import torch_isnan
-from tests.common import assert_equal, skipif_param
+from tests.common import assert_equal, skipif_param, skip_param_rocm, skipif_rocm
 
 try:
     from contextlib import ExitStack  # python 3
@@ -492,7 +492,7 @@ def test_elbo_berns(method, enumerate1, enumerate2, enumerate3, num_samples):
     ]))
 
 
-@pytest.mark.parametrize("num_samples", [None, 2000])
+@pytest.mark.parametrize("num_samples", [None, skip_param_rocm(2000)])
 @pytest.mark.parametrize("max_plate_nesting", [0, 1])
 @pytest.mark.parametrize("enumerate1", ["sequential", "parallel"])
 @pytest.mark.parametrize("enumerate2", ["sequential", "parallel"])
@@ -690,6 +690,7 @@ def test_elbo_iplate(plate_dim, enumerate1, enumerate2):
 ])
 @pytest.mark.parametrize("inner_dim", [2])
 @pytest.mark.parametrize("outer_dim", [2])
+@skipif_rocm
 def test_elbo_plate_plate(outer_dim, inner_dim, enumerate1, enumerate2, enumerate3, enumerate4, num_samples):
     pyro.clear_param_store()
     num_particles = 1 if all([enumerate1, enumerate2, enumerate3, enumerate4]) else 100000
@@ -751,6 +752,7 @@ def test_elbo_plate_plate(outer_dim, inner_dim, enumerate1, enumerate2, enumerat
 ])
 @pytest.mark.parametrize("inner_dim", [2])
 @pytest.mark.parametrize("outer_dim", [3])
+@skipif_rocm
 def test_elbo_plate_iplate(outer_dim, inner_dim, enumerate1, enumerate2, enumerate3, num_samples):
     pyro.clear_param_store()
     num_particles = 1 if all([enumerate1, enumerate2, enumerate3]) else 100000

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -15,7 +15,7 @@ from pyro.distributions.testing import fakes
 from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, JitTraceMeanField_ELBO, Trace_ELBO,
                         TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO, config_enumerate)
 from pyro.optim import Adam
-from tests.common import assert_equal, xfail_if_not_implemented, xfail_param
+from tests.common import assert_equal, xfail_if_not_implemented, xfail_param, skipif_rocm
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ def DiffTrace_ELBO(*args, **kwargs):
     (TraceEnum_ELBO, False),
     (TraceEnum_ELBO, True),
 ])
+@skipif_rocm
 def test_subsample_gradient(Elbo, reparameterized, has_rsample, subsample, local_samples, scale):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
@@ -140,6 +141,7 @@ def test_plate(Elbo, reparameterized):
 
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, DiffTrace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@skipif_rocm
 def test_plate_elbo_vectorized_particles(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -10,7 +10,7 @@ import pyro.optim as optim
 import pyro.poutine as poutine
 from pyro.infer.autoguide import AutoDelta, AutoDiagonalNormal
 from pyro.infer import Predictive, SVI, Trace_ELBO
-from tests.common import assert_close
+from tests.common import assert_close, rocm_env
 
 
 def model(num_trials):
@@ -36,6 +36,7 @@ def beta_guide(num_trials):
 
 
 @pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.skipif(rocm_env, reason="parameter invalid values on ROCm")
 def test_posterior_predictive_svi_manual_guide(parallel):
     true_probs = torch.ones(5) * 0.7
     num_trials = torch.ones(5) * 1000

--- a/tests/infer/test_smcfilter.py
+++ b/tests/infer/test_smcfilter.py
@@ -9,7 +9,7 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import SMCFilter
 from pyro.infer.smcfilter import _systematic_sample
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm
 
 
 @pytest.mark.parametrize("size", range(1, 32))
@@ -79,6 +79,7 @@ class SmokeGuide:
 @pytest.mark.parametrize("state_size", [2, 5, 1])
 @pytest.mark.parametrize("plate_size", [3, 7, 1])
 @pytest.mark.parametrize("num_steps", [1, 2, 10])
+@skipif_rocm
 def test_smoke(max_plate_nesting, state_size, plate_size, num_steps):
     model = SmokeModel(state_size, plate_size)
     guide = SmokeGuide(state_size, plate_size)
@@ -195,6 +196,7 @@ def test_likelihood_ratio():
     assert(score_latent(zs_pred, ys_true) > score_latent(zs, ys_true))
 
 
+@skipif_rocm
 def test_gaussian_filter():
     dim = 4
     init_dist = dist.MultivariateNormal(torch.zeros(dim), scale_tril=torch.eye(dim) * 10)

--- a/tests/infer/test_svgd.py
+++ b/tests/infer/test_svgd.py
@@ -48,10 +48,10 @@ def test_mean_variance(latent_dist, mode, stein_kernel, verbose=True):
     final_particles = svgd.get_named_particles()['z']
 
     if verbose:
-        print("[mean]: actual, expected = ", final_particles.mean(0).data.numpy(),
-              latent_dist.mean.data.numpy())
-        print("[var]: actual, expected = ", final_particles.var(0).data.numpy(),
-              latent_dist.variance.data.numpy())
+        print("[mean]: actual, expected = ", final_particles.mean(0).data.cpu().numpy(),
+              latent_dist.mean.data.cpu().numpy())
+        print("[var]: actual, expected = ", final_particles.var(0).data.cpu().numpy(),
+              latent_dist.variance.data.cpu().numpy())
 
     assert_equal(final_particles.mean(0), latent_dist.mean, prec=0.01)
     prec = 0.05 if mode == 'multivariate' else 0.02

--- a/tests/infer/test_tmc.py
+++ b/tests/infer/test_tmc.py
@@ -17,7 +17,7 @@ from pyro.infer import config_enumerate
 from pyro.infer.importance import vectorized_importance_weights
 from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.traceenum_elbo import TraceEnum_ELBO
-from tests.common import assert_equal
+from tests.common import assert_equal, skip_param_rocm
 
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def test_tmc_normals_chain_iwae(depth, num_samples, max_plate_nesting,
 @pytest.mark.parametrize("num_samples,expand", [(200, False)])
 @pytest.mark.parametrize("max_plate_nesting", [0])
 @pytest.mark.parametrize("guide_type", ["prior", "factorized", "nonfactorized"])
-@pytest.mark.parametrize("reparameterized", [False, True])
+@pytest.mark.parametrize("reparameterized", [skip_param_rocm(False), True])
 @pytest.mark.parametrize("tmc_strategy", ["diagonal", "mixture"])
 def test_tmc_normals_chain_gradient(depth, num_samples, max_plate_nesting, expand,
                                     guide_type, reparameterized, tmc_strategy):

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -11,7 +11,7 @@ import pyro.poutine as poutine
 import pytest
 from pyro.infer.importance import psis_diagnostic
 from pyro.infer.util import MultiFrameTensor
-from tests.common import assert_equal
+from tests.common import assert_equal, skip_param_rocm
 
 
 def xy_model():
@@ -51,7 +51,7 @@ def test_multi_frame_tensor():
         assert_equal(actual_sum, expected_sum, msg=name)
 
 
-@pytest.mark.parametrize('max_particles', [250 * 1000, 500 * 1000])
+@pytest.mark.parametrize('max_particles', [250 * 1000, skip_param_rocm(500 * 1000)])
 @pytest.mark.parametrize('scale,krange', [(0.5, (0.7, 0.9)),
                                           (0.95, (0.05, 0.2))])
 @pytest.mark.parametrize('zdim', [1, 5])

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -228,7 +228,7 @@ class GaussianPyramidTests(TestCase):
             permutation = list(range(2 ** (n - 1)))
             if n > 1:
                 while permutation == list(range(2 ** (n - 1))):
-                    permutation = torch.randperm(2 ** (n - 1)).numpy().tolist()
+                    permutation = torch.randperm(2 ** (n - 1)).cpu().numpy().tolist()
             self.model_permutations.append(permutation)
 
             unpermutation = list(range(len(permutation)))

--- a/tests/ops/test_arrowhead.py
+++ b/tests/ops/test_arrowhead.py
@@ -6,10 +6,11 @@ import torch
 
 from pyro.ops.arrowhead import SymmArrowhead, sqrt, triu_gram, triu_inverse, triu_matvecmul
 
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm
 
 
 @pytest.mark.parametrize('head_size', [0, 2, 5])
+@skipif_rocm
 def test_utilities(head_size):
     size = 5
     cov = torch.randn(size, size)

--- a/tests/ops/test_gamma_gaussian.py
+++ b/tests/ops/test_gamma_gaussian.py
@@ -15,7 +15,7 @@ from pyro.ops.gamma_gaussian import (
     matrix_and_mvn_to_gamma_gaussian,
     gamma_and_mvn_to_gamma_gaussian,
 )
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm
 from tests.ops.gamma_gaussian import assert_close_gamma_gaussian, random_gamma, random_gamma_gaussian
 from tests.ops.gaussian import random_mvn
 
@@ -118,6 +118,7 @@ def test_add(shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize_shape(batch_shape, left, right):
     dim = left + right
     g = random_gamma_gaussian(batch_shape, dim)
@@ -128,6 +129,7 @@ def test_marginalize_shape(batch_shape, left, right):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize(batch_shape, left, right):
     dim = left + right
     g = random_gamma_gaussian(batch_shape, dim)
@@ -142,6 +144,7 @@ def test_marginalize(batch_shape, left, right):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize_condition(sample_shape, batch_shape, left, right):
     dim = left + right
     g = random_gamma_gaussian(batch_shape, dim)
@@ -174,6 +177,7 @@ def test_condition(sample_shape, batch_shape, left, right):
 
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
+@skipif_rocm
 def test_logsumexp(batch_shape, dim):
     g = random_gamma_gaussian(batch_shape, dim)
     g.info_vec *= 0.1  # approximately centered
@@ -191,6 +195,7 @@ def test_logsumexp(batch_shape, dim):
 @pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
+@skipif_rocm
 def test_gamma_and_mvn_to_gamma_gaussian(sample_shape, batch_shape, dim):
     gamma = random_gamma(batch_shape)
     mvn = random_mvn(batch_shape, dim)
@@ -210,6 +215,7 @@ def test_gamma_and_mvn_to_gamma_gaussian(sample_shape, batch_shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("x_dim", [1, 2, 3])
 @pytest.mark.parametrize("y_dim", [1, 2, 3])
+@skipif_rocm
 def test_matrix_and_mvn_to_gamma_gaussian(sample_shape, batch_shape, x_dim, y_dim):
     matrix = torch.randn(batch_shape + (x_dim, y_dim))
     y_mvn = random_mvn(batch_shape, y_dim)
@@ -246,6 +252,7 @@ def test_matrix_and_mvn_to_gamma_gaussian(sample_shape, batch_shape, x_dim, y_di
 @pytest.mark.parametrize("x_rank,y_rank", [
     (1, 1), (4, 1), (1, 4), (4, 4)
 ], ids=str)
+@skipif_rocm
 def test_gamma_gaussian_tensordot(dot_dims,
                                   x_batch_shape, x_dim, x_rank,
                                   y_batch_shape, y_dim, y_rank):

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -10,7 +10,7 @@ from torch.nn.functional import pad
 import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gaussian import AffineNormal, Gaussian, gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
-from tests.common import assert_close
+from tests.common import assert_close, skipif_rocm, skip_param_rocm
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
 
 
@@ -107,6 +107,7 @@ def test_add(shape, dim):
 @pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
+@skipif_rocm
 def test_rsample_shape(sample_shape, batch_shape, dim):
     mvn = random_mvn(batch_shape, dim)
     g = mvn_to_gaussian(mvn)
@@ -118,6 +119,7 @@ def test_rsample_shape(sample_shape, batch_shape, dim):
 
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
+@skipif_rocm
 def test_rsample_distribution(batch_shape, dim):
     num_samples = 20000
     mvn = random_mvn(batch_shape, dim)
@@ -143,6 +145,7 @@ def test_rsample_distribution(batch_shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize_shape(batch_shape, left, right):
     dim = left + right
     g = random_gaussian(batch_shape, dim)
@@ -153,6 +156,7 @@ def test_marginalize_shape(batch_shape, left, right):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize(batch_shape, left, right):
     dim = left + right
     g = random_gaussian(batch_shape, dim)
@@ -166,6 +170,7 @@ def test_marginalize(batch_shape, left, right):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+@skipif_rocm
 def test_marginalize_condition(sample_shape, batch_shape, left, right):
     dim = left + right
     g = random_gaussian(batch_shape, dim)
@@ -203,7 +208,7 @@ def test_condition(sample_shape, batch_shape, left, right):
 
 
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
-@pytest.mark.parametrize("dim", [1, 2, 3])
+@pytest.mark.parametrize("dim", [1, skip_param_rocm(2), skip_param_rocm(3)])
 def test_logsumexp(batch_shape, dim):
     gaussian = random_gaussian(batch_shape, dim)
     gaussian.info_vec *= 0.1  # approximately centered
@@ -220,6 +225,7 @@ def test_logsumexp(batch_shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("x_dim", [1, 2, 3])
 @pytest.mark.parametrize("y_dim", [1, 2, 3])
+@skipif_rocm
 def test_affine_normal(batch_shape, x_dim, y_dim):
     matrix = torch.randn(batch_shape + (x_dim, y_dim))
     loc = torch.randn(batch_shape + (y_dim,))
@@ -258,6 +264,7 @@ def test_affine_normal(batch_shape, x_dim, y_dim):
 @pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
+@skipif_rocm
 def test_mvn_to_gaussian(sample_shape, batch_shape, dim):
     mvn = random_mvn(batch_shape, dim)
     gaussian = mvn_to_gaussian(mvn)
@@ -271,6 +278,7 @@ def test_mvn_to_gaussian(sample_shape, batch_shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("x_dim", [1, 2, 3])
 @pytest.mark.parametrize("y_dim", [1, 2, 3])
+@skipif_rocm
 def test_matrix_and_mvn_to_gaussian(sample_shape, batch_shape, x_dim, y_dim):
     matrix = torch.randn(batch_shape + (x_dim, y_dim))
     y_mvn = random_mvn(batch_shape, y_dim)
@@ -288,6 +296,7 @@ def test_matrix_and_mvn_to_gaussian(sample_shape, batch_shape, x_dim, y_dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("x_dim", [1, 2, 3])
 @pytest.mark.parametrize("y_dim", [1, 2, 3])
+@skipif_rocm
 def test_matrix_and_mvn_to_gaussian_2(sample_shape, batch_shape, x_dim, y_dim):
     matrix = torch.randn(batch_shape + (x_dim, y_dim))
     y_mvn = random_mvn(batch_shape, y_dim)
@@ -322,6 +331,7 @@ def test_matrix_and_mvn_to_gaussian_2(sample_shape, batch_shape, x_dim, y_dim):
 @pytest.mark.parametrize("x_rank,y_rank", [
     (1, 1), (4, 1), (1, 4), (4, 4)
 ], ids=str)
+@skipif_rocm
 def test_gaussian_tensordot(dot_dims,
                             x_batch_shape, x_dim, x_rank,
                             y_batch_shape, y_dim, y_rank):

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.ops.linalg import rinverse
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 @pytest.mark.parametrize("A", [
@@ -17,6 +17,7 @@ from tests.common import assert_equal
     torch.eye(40)
     ])
 @pytest.mark.parametrize("use_sym", [True, False])
+@skipif_rocm
 def test_sym_rinverse(A, use_sym):
     d = A.shape[-1]
     assert_equal(rinverse(A, sym=use_sym), torch.inverse(A), prec=1e-8)

--- a/tests/ops/test_ssm_gp.py
+++ b/tests/ops/test_ssm_gp.py
@@ -5,11 +5,12 @@ import pytest
 import torch
 
 from pyro.ops.ssm_gp import MaternKernel
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 @pytest.mark.parametrize('num_gps', [1, 2, 3])
 @pytest.mark.parametrize('nu', [0.5, 1.5, 2.5])
+@skipif_rocm
 def test_matern_kernel(num_gps, nu):
     mk = MaternKernel(nu=nu, num_gps=num_gps, length_scale_init=0.1 + torch.rand(num_gps))
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -9,7 +9,7 @@ import torch
 from pyro.ops.stats import (_cummin, autocorrelation, autocovariance, crps_empirical, effective_sample_size,
                             fit_generalized_pareto, gelman_rubin, hpdi, pi, quantile, resample, split_gelman_rubin,
                             waic)
-from tests.common import assert_close, assert_equal, xfail_if_not_implemented
+from tests.common import assert_close, assert_equal, xfail_if_not_implemented, rocm_env
 
 
 @pytest.mark.parametrize('replacement', [True, False])
@@ -33,6 +33,7 @@ def test_resample(replacement):
 
 
 @pytest.mark.init(rng_seed=3)
+@pytest.mark.skipif(rocm_env, reason="test fails on ROCm")
 def test_quantile():
     x = torch.tensor([0., 1., 2.])
     y = torch.rand(2000)

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -12,7 +12,7 @@ import pyro
 from pyro.ops.tensor_utils import (block_diag_embed, block_diagonal, convolve, dct, idct, next_fast_len,
                                    periodic_cumsum, periodic_features, periodic_repeat, precision_to_scale_tril,
                                    repeated_matmul)
-from tests.common import assert_close, assert_equal
+from tests.common import assert_close, assert_equal, skipif_rocm
 
 pytestmark = pytest.mark.stage('unit')
 
@@ -162,6 +162,7 @@ def test_next_fast_len():
     ((), (5,)),
     ((3,), (4,)),
 ])
+@skipif_rocm
 def test_precision_to_scale_tril(batch_shape, event_shape):
     x = torch.randn(batch_shape + event_shape + event_shape)
     precision = x.matmul(x.transpose(-2, -1))

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -93,7 +93,7 @@ def test_convolve_shape(m, n, mode):
     signal = torch.randn(m)
     kernel = torch.randn(n)
     actual = convolve(signal, kernel, mode)
-    expected = np.convolve(signal, kernel, mode=mode)
+    expected = np.convolve(signal.cpu(), kernel.cpu(), mode=mode)
     assert actual.shape == expected.shape
 
 
@@ -106,7 +106,7 @@ def test_convolve(batch_shape, m, n, mode):
     kernel = torch.randn(*batch_shape, n)
     actual = convolve(signal, kernel, mode)
     expected = torch.stack([
-        torch.tensor(np.convolve(s, k, mode=mode))
+        torch.tensor(np.convolve(s.cpu(), k.cpu(), mode=mode))
         for s, k in zip(signal.reshape(-1, m), kernel.reshape(-1, n))
     ]).reshape(*batch_shape, -1)
     assert_close(actual, expected)
@@ -129,7 +129,7 @@ def test_repeated_matmul(size, n):
 def test_dct(shape):
     x = torch.randn(shape)
     actual = dct(x)
-    expected = torch.from_numpy(fftpack.dct(x.numpy(), norm='ortho'))
+    expected = torch.from_numpy(fftpack.dct(x.cpu().numpy(), norm='ortho'))
     assert_close(actual, expected)
 
 
@@ -137,7 +137,7 @@ def test_dct(shape):
 def test_idct(shape):
     x = torch.randn(shape)
     actual = idct(x)
-    expected = torch.from_numpy(fftpack.idct(x.numpy(), norm='ortho'))
+    expected = torch.from_numpy(fftpack.idct(x.cpu().numpy(), norm='ortho'))
     assert_close(actual, expected)
 
 

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -7,13 +7,14 @@ import torch
 
 from pyro.ops.welford import WelfordArrowheadCovariance, WelfordCovariance
 from pyro.util import optional
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 
 @pytest.mark.parametrize('n_samples,dim_size', [(1000, 1),
                                                 (1000, 7),
                                                 (1, 1)])
 @pytest.mark.init(rng_seed=7)
+@skipif_rocm
 def test_welford_diagonal(n_samples, dim_size):
     w = WelfordCovariance(diagonal=True)
     loc = torch.zeros(dim_size)
@@ -36,6 +37,7 @@ def test_welford_diagonal(n_samples, dim_size):
                                                 (1000, 7),
                                                 (1, 1)])
 @pytest.mark.init(rng_seed=7)
+@skipif_rocm
 def test_welford_dense(n_samples, dim_size):
     w = WelfordCovariance(diagonal=False)
     loc = torch.zeros(dim_size)
@@ -59,6 +61,7 @@ def test_welford_dense(n_samples, dim_size):
     (1000, 5, 5)
 ])
 @pytest.mark.parametrize('regularize', [True, False])
+@skipif_rocm
 def test_welford_arrowhead(n_samples, dim_size, head_size, regularize):
     adapt_scheme = WelfordArrowheadCovariance(head_size=head_size)
     loc = torch.zeros(dim_size)

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -10,7 +10,7 @@ import pyro.distributions as dist
 import pyro.optim
 import pyro.poutine as poutine
 from pyro.optim.multi import MixedMultiOptimizer, Newton, PyroMultiOptimizer, TorchMultiOptimizer
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_rocm
 
 FACTORIES = [
     lambda: PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05})),
@@ -24,6 +24,7 @@ FACTORIES = [
 
 
 @pytest.mark.parametrize('factory', FACTORIES)
+@skipif_rocm
 def test_optimizers(factory):
     optim = factory()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,7 +8,7 @@ from subprocess import check_call
 
 import pytest
 
-from tests.common import EXAMPLES_DIR, requires_cuda, xfail_param
+from tests.common import EXAMPLES_DIR, requires_cuda, xfail_param, skip_param_rocm
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.stage('test_examples')
@@ -107,13 +107,13 @@ CUDA_EXAMPLES = [
     'air/main.py --num-steps=1 --cuda',
     'baseball.py --num-samples=200 --warmup-steps=100 --num-chains=2 --cuda',
     'contrib/cevae/synthetic.py --num-epochs=1 --cuda',
-    'contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 --cuda',
-    'contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -nb=16 --cuda',
-    'contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 --haar --cuda',
-    'contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 --cuda',
-    'contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 --haar --cuda',
-    'contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --cuda',
-    'lkj.py --n=50 --num-chains=1 --warmup-steps=100 --num-samples=200 --cuda',
+    skip_param_rocm('contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 --cuda'),
+    skip_param_rocm('contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -nb=16 --cuda'),
+    skip_param_rocm('contrib/epidemiology/sir.py -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 --haar --cuda'),
+    skip_param_rocm('contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 --cuda'),
+    skip_param_rocm('contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 --haar --cuda'),
+    skip_param_rocm('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --cuda'),
+    skip_param_rocm('lkj.py --n=50 --num-chains=1 --warmup-steps=100 --num-samples=200 --cuda'),
     'dmm/dmm.py --num-epochs=1 --cuda',
     'dmm/dmm.py --num-epochs=1 --num-iafs=1 --cuda',
     'dmm/dmm.py --num-epochs=1 --tmc --tmc-num-samples=2 --cuda',
@@ -135,9 +135,9 @@ CUDA_EXAMPLES = [
     'hmm.py --num-steps=1 --truncate=10 --model=4 --tmc --tmc-num-samples=2 --cuda',
     'hmm.py --num-steps=1 --truncate=10 --model=5 --tmc --tmc-num-samples=2 --cuda',
     'hmm.py --num-steps=1 --truncate=10 --model=6 --tmc --tmc-num-samples=2 --cuda',
-    'sir_hmc.py -t=2 -w=2 -n=4 -d=2 -m=1 --enum --cuda',
-    'sir_hmc.py -t=2 -w=2 -n=4 -d=2 -p=10000 --sequential --cuda',
-    'sir_hmc.py -t=2 -w=2 -n=4 -d=100 -p=10000 --cuda',
+    skip_param_rocm('sir_hmc.py -t=2 -w=2 -n=4 -d=2 -m=1 --enum --cuda'),
+    skip_param_rocm('sir_hmc.py -t=2 -w=2 -n=4 -d=2 -p=10000 --sequential --cuda'),
+    skip_param_rocm('sir_hmc.py -t=2 -w=2 -n=4 -d=100 -p=10000 --cuda'),
     'vae/vae.py --num-epochs=1 --cuda',
     'vae/ss_vae_M2.py --num-epochs=1 --cuda',
     'vae/ss_vae_M2.py --num-epochs=1 --aux-loss --cuda',


### PR DESCRIPTION
This PR has changes for:
1. Common utilities to identify and skip tests on ROCm environment
2. Skipping all the tests in tests/contrib/gp/test_conditional.py because of MAGMA usage
3. Skipping tests in tests/distributions/ that fail on ROCm because of no MAGMA
4. Skipping tests in tests/distributions/ that fail on ROCm (marked separately than previous point)
5. Skipping tests in tests/infer/ that fail on ROCm 
6. Skipping tests in tests/ops/ that fail on ROCm 